### PR TITLE
Make the max potion stack size configurable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ minecraft {
     //
     // Use non-default mappings at your own risk. They may not always work.
     // Simply re-run your setup task after changing the mappings to update your workspace.
-    mappings channel: 'official', version: '1.19.2'
+    mappings channel: 'official', version: "${mc_version}"
 
     // accessTransformer = file('src/main/resources/META-INF/accesstransformer.cfg') // Currently, this location cannot be changed from the default.
 
@@ -129,7 +129,7 @@ dependencies {
     // Specify the version of Minecraft to use. If this is any group other than 'net.minecraft', it is assumed
     // that the dep is a ForgeGradle 'patcher' dependency, and its patches will be applied.
     // The userdev artifact is a special name and will get all sorts of transformations applied to it.
-    minecraft 'net.minecraftforge:forge:1.19.2-43.2.4'
+    minecraft "net.minecraftforge:forge:${mc_version}-${forge_version}"
 
     // Real mod deobf dependency examples - these get remapped to your current mappings
     // compileOnly fg.deobf("mezz.jei:jei-${mc_version}:${jei_version}:api") // Adds JEI API as a compile dependency

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,8 +3,9 @@
 org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
 
-mod_version=2.0
+mod_version=3.0
 mod_vendor=furreddraco
 mod_id=stacking_potions
 
 mc_version=1.19.2
+forge_version=43.2.21

--- a/src/main/java/com/furreddraco/stacking_potions/StackingPotions.java
+++ b/src/main/java/com/furreddraco/stacking_potions/StackingPotions.java
@@ -1,11 +1,14 @@
 package com.furreddraco.stacking_potions;
 
+import com.furreddraco.stacking_potions.config.StackingPotionsCommonConfig;
 import com.mojang.logging.LogUtils;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.PotionItem;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.config.ModConfig;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.registries.ForgeRegistries;
@@ -14,17 +17,19 @@ import org.slf4j.Logger;
 import java.lang.reflect.Field;
 
 @Mod("stacking_potions")
-public class stackingPotions
+public class StackingPotions
 {
     private static final Logger LOGGER = LogUtils.getLogger();
 
-    public stackingPotions()
+    public StackingPotions()
     {
         IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
 
         modEventBus.addListener(this::commonSetup);
 
         MinecraftForge.EVENT_BUS.register(this);
+
+        ModLoadingContext.get().registerConfig(ModConfig.Type.COMMON, StackingPotionsCommonConfig.SPEC, "stacking_potions.toml");
     }
 
     private void commonSetup(final FMLCommonSetupEvent event)
@@ -35,10 +40,10 @@ public class stackingPotions
                     try {
                         Field stackSizeField = Item.class.getDeclaredField("f_41370_");
                         stackSizeField.setAccessible(true);
-                        stackSizeField.set(item, 64);
-                        LOGGER.info("stacking_potions: stack size for potion " + item.getDescriptionId() + "changed to 64");
+                        stackSizeField.set(item, StackingPotionsCommonConfig.POTION_STACKING_LIMIT.get());
+                        LOGGER.info("stacking_potions: stack size for potion " + item.getDescriptionId() + "changed to " + StackingPotionsCommonConfig.POTION_STACKING_LIMIT.get());
                     } catch (Exception ex) {
-                        LOGGER.error("stacking_potions: " + ex.toString());
+                        LOGGER.error("stacking_potions: " + ex);
                     }
                 }
             }

--- a/src/main/java/com/furreddraco/stacking_potions/config/StackingPotionsCommonConfig.java
+++ b/src/main/java/com/furreddraco/stacking_potions/config/StackingPotionsCommonConfig.java
@@ -1,0 +1,22 @@
+package com.furreddraco.stacking_potions.config;
+
+import net.minecraftforge.common.ForgeConfigSpec;
+
+public class StackingPotionsCommonConfig {
+    public static final ForgeConfigSpec.Builder BUILDER = new ForgeConfigSpec.Builder();
+    public static final ForgeConfigSpec SPEC;
+
+
+    public static final ForgeConfigSpec.ConfigValue<Integer> POTION_STACKING_LIMIT;
+
+
+    static {
+        BUILDER.push("Config for Stacking Potions");
+
+        POTION_STACKING_LIMIT = BUILDER.comment("The new potion stacking limit. Default is 64.")
+                .defineInRange("Potion Stacking Limit", 64, 1, 64);
+
+        BUILDER.pop();
+        SPEC = BUILDER.build();
+    }
+}

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -42,7 +42,7 @@ authors="Furred Draco" #optional
 
 # The description text for the mod (multi line!) (#mandatory)
 description='''
-This mod allows potions to stack together
+This mod allows potions to stack together to a configurable stack size.
 '''
 # A dependency - use the . to indicate dependency for a specific modid. Dependencies are optional.
 [[dependencies.stacking_potions]] #optional


### PR DESCRIPTION
This makes the new stack size for potions configurable, so if you wanted to make it 16 instead of 64, you can do that in the config. 
I also did some other smaller tweaks, mostly doing some gradle stuff and bumping the mod version (I don't know how you label versions so I just did 3.0 for now).